### PR TITLE
add custom webdav url from nextcloud with LDAP authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Create a NextCloud filesystem disk:
 	    'userName'   => 'johndoe',
 	    'password'   => 'secret',
 	    'pathPrefix' => '', // provide a subfolder name if your NextCloud instance isn't running directly on a domain, e.g. https://example.com/drive
+	    'objectGuid' => 'OBJECT_GUID', // optional params, used when NextCloud instance is using AD/LDAP as Authentication provider so the webDav url will be look like e.g https://example.com/remote.php/dav/files/OBJECT_GUID/
 	],
 	...
 ];
@@ -50,6 +51,7 @@ If you discover any security related issues, please email jakub.jedlikowski@gmai
 
 -   [Jakub Jedlikowski][link-author]
 -   [Pascal Baljet][link-author-2]
+-   [Bashir Arrohman][link-author-3]
 
 ## License
 
@@ -57,3 +59,4 @@ The MIT License (MIT). Please see [License File](LICENSE.md) for more informatio
 
 [link-author]: https://github.com/jedlikowski
 [link-author-2]: https://github.com/pascalbaljet
+[link-author-3]: https://github.com/tyangjawi03

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Based on https://github.com/pascalbaljetmedia/laravel-webdav
 Via Composer
 
 ```bash
-$ composer require jedlikowski/laravel-nextcloud
+$ composer require tyangjawi03/laravel-nextcloud
 ```
 
 ## Usage

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "~5.6|^7.0",
-        "illuminate/filesystem": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.*",
+        "illuminate/filesystem": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.* || 6.* || 7.*",
         "league/flysystem-webdav": "^1.0.8",
         "jakeasmith/http_build_url": "^1"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "jedlikowski/laravel-nextcloud",
+    "name": "tyangjawi03/laravel-nextcloud",
     "type": "library",
     "version": "1.0.0",
     "description": "Laravel 5 NextCloud Filesystem",
@@ -7,11 +7,15 @@
         "jedlikowski",
         "laravel-nextcloud"
     ],
-    "homepage": "https://github.com/jedlikowski/laravel-nextcloud",
+    "homepage": "https://github.com/tyangjawi03/laravel-nextcloud",
     "license": "MIT",
     "authors": [
         {
             "name": "Jakub Jedlikowski",
+            "role": "Developer"
+        },
+        {
+            "name": "Bashir Arrohman",
             "role": "Developer"
         }
     ],

--- a/src/NextCloudServiceProvider.php
+++ b/src/NextCloudServiceProvider.php
@@ -13,7 +13,7 @@ class NextCloudServiceProvider extends ServiceProvider
     public function boot()
     {
         Storage::extend('nextcloud', function ($app, $config) {
-            $pathPrefix = 'remote.php/dav/files/' . $config['userName'];
+            $pathPrefix = 'remote.php/dav/files/' . (isset($config['objectGuid']) ? $config['objectGuid'] : $config['userName']);
             if (array_key_exists('pathPrefix', $config)) {
                 $pathPrefix = rtrim($config['pathPrefix'], '/') . '/' . $pathPrefix;
             }


### PR DESCRIPTION
Hello Jakub Jedlikowski,

Thanks for your Laravel-nextcloud package. It's very helpful for me.

There was an issue when the Nextcloud instance using AD/LDAP as an Authentication Provider, Nextcloud WebDav URI will look like https://example.com/remote.php/dav/files/OBJECT_GUID/ when the default is https://example.com/remote.php/dav/files/USERNAME/

I made a change to add an optional configuration for this usecase.

Best Regard